### PR TITLE
Added ability to update/clean deprecated tags and attributes

### DIFF
--- a/dist/deprecated-html.js
+++ b/dist/deprecated-html.js
@@ -1,0 +1,86 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.fontTagSizeToCss = exports.getDeprecatedAttrsForNode = exports.hasDeprecatedAttrs = exports.isTagDeprecated = exports.deprecatedAttrs = exports.deprecatedTags = void 0;
+const deprecatedTags = ['acronym', 'applet', 'basefont', 'big', 'center', 'dir', 'font', 'frame', 'frameset', 'isindex', 'noframes', 's', 'strike', 'tt', 'u'];
+exports.deprecatedTags = deprecatedTags;
+const deprecatedAttrs = ['rev', 'charset', 'shape', 'coords', 'longdesc', 'target', 'nohref', 'profile', 'version', 'name', 'scheme', 'archive', 'classid', 'codebase', 'codetype', 'declare', 'standby', 'valuetype', 'type', 'axis', 'abbr', 'scope', 'align', 'alink', 'link', 'vlink', 'text', 'background', 'bgcolor', 'border', 'cellpadding', 'cellspacing', 'char', 'charoff', 'clear', 'compact', 'frame', 'compact', 'frame', 'frameborder', 'hspace', 'vspace', 'marginheight', 'marginwidth', 'noshade', 'nowrap', 'rules', 'scrolling', 'size', 'type', 'valign', 'width'];
+exports.deprecatedAttrs = deprecatedAttrs;
+
+const isTagDeprecated = node => {
+  return deprecatedTags.includes(node.name);
+};
+
+exports.isTagDeprecated = isTagDeprecated;
+
+const hasDeprecatedAttrs = node => {
+  if (node.attribs) {
+    return Object.keys(node.attribs).some(attr => deprecatedAttrs.includes(attr));
+  } // node has no attrs, thus no deprecated attrs
+
+
+  return false;
+};
+
+exports.hasDeprecatedAttrs = hasDeprecatedAttrs;
+
+const getDeprecatedAttrsForNode = node => {
+  if (node.attribs) {
+    return Object.keys(node.attribs).filter(attr => deprecatedAttrs.includes(attr));
+  } // return empty array if node has no attrs
+
+
+  return [];
+};
+
+exports.getDeprecatedAttrsForNode = getDeprecatedAttrsForNode;
+
+const fontTagSizeToCss = size => {
+  const defaultSize = 3; // handle relative sizes
+
+  if (size.charAt(0) === '-') {
+    size = defaultSize - +size.charAt(1);
+  } else if (size.charAt(1) === '+') {
+    size = defaultSize + +size.charAt(1);
+  }
+
+  switch (size) {
+    case 1:
+      size = 'x-small';
+      break;
+
+    case 2:
+      size = 'small';
+      break;
+
+    case 3:
+      size = 'medium';
+      break;
+
+    case 4:
+      size = 'large';
+      break;
+
+    case 5:
+      size = 'x-large';
+      break;
+
+    case 6:
+      size = 'xx-large';
+      break;
+
+    case 7:
+      size = 'xx-large';
+      break;
+
+    default:
+      size = 'medium';
+      break;
+  }
+
+  return size;
+};
+
+exports.fontTagSizeToCss = fontTagSizeToCss;

--- a/dist/index.js
+++ b/dist/index.js
@@ -22,6 +22,8 @@ var _htmlparser2html = _interopRequireDefault(require("./htmlparser2html"));
 
 var _handleNonstdTags = require("./handle-nonstd-tags");
 
+var _deprecatedHtml = require("./deprecated-html");
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 // global hashmap to keep track of classes that have already been created
@@ -131,6 +133,89 @@ const addInlineStylesToStyleMap = dom => {
   });
 };
 
+let deprecationClasses = [];
+
+const addClassToNode = (node, className) => {
+  node.attribs === undefined ? node.attribs = {
+    class: className
+  } : node.attribs.class === undefined ? node.attribs.class = className : node.attribs.class = `${node.attribs.class} ${className}`;
+  return node;
+};
+
+const updateDeprecatedTag = node => {
+  switch (node.name) {
+    case 'center':
+      node.name = 'p';
+      addClassToNode(node, 'centered');
+      deprecationClasses.push({
+        className: 'centered',
+        declaration: 'text-align:center;'
+      });
+      break;
+
+    case 'basefont':
+    case 'font':
+      let fontColor, fontFace, fontSize, declaration;
+
+      const fontClass = _uniqueNamesGenerator.default.generate('-');
+
+      if (node.attribs) {
+        fontColor = node.attribs.color || '';
+        fontFace = node.attribs.face || '';
+        fontSize = (0, _deprecatedHtml.fontTagSizeToCss)(node.attribs.size);
+        declaration = `color:${fontColor};font-family:${fontFace};font-size:${fontSize}`;
+      }
+
+      if (node.children && node.children.length > 0) {
+        const updatedChildren = node.children.map(child => addClassToNode(child, fontClass)); // remove font node, replace it with the font node's children
+
+        node.parent.children = updatedChildren;
+      }
+
+      break;
+  }
+};
+
+const updateDeprecatedAttr = (node, attr) => {
+  let declaration = '';
+
+  switch (attr) {
+    case 'align':
+      declaration = `text-align:${node.attribs[attr]};`;
+      break;
+
+    case 'border':
+      declaration = `border-width:${node.attribs[attr]};`;
+      break;
+
+    case 'width':
+      declaration = `width:${node.attribs[attr]};`;
+      break;
+
+    case 'valign':
+      declaration = `vertical-align:${node.attribs[attr]};`;
+      break;
+  }
+
+  if (!styleMap.has(declaration)) {
+    const attrClass = _uniqueNamesGenerator.default.generate('-');
+
+    addStyleToMap(declaration, attrClass);
+  }
+};
+
+const handleDeprecations = node => {
+  if ((0, _deprecatedHtml.isTagDeprecated)(node)) {
+    updateDeprecatedTag(node);
+  }
+
+  const deprecatedAttrs = (0, _deprecatedHtml.getDeprecatedAttrsForNode)(node);
+
+  if (deprecatedAttrs.length > 0) {
+    deprecatedAttrs.forEach(attr => updateDeprecatedAttr(node, attr));
+  }
+};
+
 const cleanNode = node => {
   if (node.attribs && node.attribs.style) {
     const minStyle = minifyCss(node.attribs.style);
@@ -146,6 +231,7 @@ const cleanNode = node => {
     node.attribs.style = undefined;
   }
 
+  handleDeprecations(node);
   return node;
 };
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -136,16 +136,27 @@ const addInlineStylesToStyleMap = dom => {
 let deprecationClasses = [];
 
 const addClassToNode = (node, className) => {
-  node.attribs === undefined ? node.attribs = {
-    class: className
-  } : node.attribs.class === undefined ? node.attribs.class = className : node.attribs.class = `${node.attribs.class} ${className}`;
+  if (node.attribs === undefined) {
+    node.attribs = {
+      class: className
+    };
+  } else {
+    if (node.attribs.class === undefined) {
+      node.attribs.class = className;
+    } else {
+      if (node.attribs.class.indexOf(className) === -1) {
+        node.attribs.class = `${node.attribs.class} ${className}`;
+      }
+    }
+  }
+
   return node;
 };
 
 const updateDeprecatedTag = node => {
   switch (node.name) {
     case 'center':
-      node.name = 'p';
+      node.name = 'div';
       addClassToNode(node, 'centered');
       deprecationClasses.push({
         className: 'centered',
@@ -164,12 +175,18 @@ const updateDeprecatedTag = node => {
         fontFace = node.attribs.face || '';
         fontSize = (0, _deprecatedHtml.fontTagSizeToCss)(node.attribs.size);
         declaration = `color:${fontColor};font-family:${fontFace};font-size:${fontSize}`;
+        deprecationClasses.push({
+          className: fontClass,
+          declaration: declaration
+        });
       }
 
       if (node.children && node.children.length > 0) {
-        const updatedChildren = node.children.map(child => addClassToNode(child, fontClass)); // remove font node, replace it with the font node's children
+        const updatedChildren = node.children.map(child => addClassToNode(child, fontClass)); // find the font tag's index in the children array
 
-        node.parent.children = updatedChildren;
+        const fontIndex = node.parent.children.findIndex(child => Object.is(node, child)); // replace the font tag with all of its children
+
+        node.parent.children.splice(fontIndex, 1, ...updatedChildren);
       }
 
       break;
@@ -177,31 +194,74 @@ const updateDeprecatedTag = node => {
 };
 
 const updateDeprecatedAttr = (node, attr) => {
+  let attrClass;
   let declaration = '';
+  let selectorExtra = '';
+  let hasSelectorExtra = false;
 
   switch (attr) {
     case 'align':
+      attrClass = `align-${node.attribs[attr]}`;
       declaration = `text-align:${node.attribs[attr]};`;
       break;
 
+    case 'bgcolor':
+      attrClass = _uniqueNamesGenerator.default.generate('-');
+      declaration = `background-color:${node.attribs[attr]};`;
+      break;
+
     case 'border':
+      attrClass = `border-width-${node.attribs[attr]}`;
       declaration = `border-width:${node.attribs[attr]};`;
       break;
 
+    case 'cellpadding':
+      attrClass = `padding-${node.attribs[attr]}`;
+      declaration = `border-collapse:collapse;padding:${node.attribs[attr]};`;
+      selectorExtra = ['th', 'td'];
+      hasSelectorExtra = true;
+      break;
+
+    case 'cellspacing':
+      attrClass = `border-spacing-${node.attribs[attr]}`;
+      declaration = `border-collapse:collapse;border-spacing:${node.attribs[attr]};`;
+      selectorExtra = ['th', 'td'];
+      hasSelectorExtra = true;
+      break;
+
     case 'width':
-      declaration = `width:${node.attribs[attr]};`;
+      const match = node.attribs[attr].match(/^(\d*|\d*\.\d*)(\w*)$/);
+      let value = match[1] || '';
+      let unit = match[2] || '';
+      unit = unit === '' ? 'px' : unit;
+      attrClass = `width-${value}${unit}`;
+      declaration = `width:${value}${unit};`;
       break;
 
     case 'valign':
+      attrClass = `vert-align-${node.attribs[attr]}`;
       declaration = `vertical-align:${node.attribs[attr]};`;
       break;
+
+    default:
+      return;
   }
 
-  if (!styleMap.has(declaration)) {
-    const attrClass = _uniqueNamesGenerator.default.generate('-');
-
+  if (!styleMap.has(declaration) && !hasSelectorExtra) {
     addStyleToMap(declaration, attrClass);
+  } else if (hasSelectorExtra) {
+    const cssSelector = selectorExtra.map(extra => {
+      return `.${attrClass} ${extra}`;
+    }).join(',\n');
+
+    _fs.default.appendFileSync(_commandLine.options.output, prettifyCss(cssSelector, declaration));
+  } else {
+    attrClass = styleMap.get(declaration).className;
   }
+
+  node.attribs[attr] = undefined; // delete deprecated attr
+
+  addClassToNode(node, attrClass);
 };
 
 const handleDeprecations = node => {
@@ -214,6 +274,8 @@ const handleDeprecations = node => {
   if (deprecatedAttrs.length > 0) {
     deprecatedAttrs.forEach(attr => updateDeprecatedAttr(node, attr));
   }
+
+  deprecationClasses.forEach(classObj => addStyleToMap((0, _sqwish.minify)(classObj.declaration), classObj.className));
 };
 
 const cleanNode = node => {
@@ -384,8 +446,8 @@ const cleanSrcFile = (dom, filename) => {
   const badStyles = getBadStyles(dom);
   addInlineStylesToStyleMap(badStyles);
   const htmlOutput = _commandLine.options['no-replace'] === undefined ? filename : createModifiedName(filename, _commandLine.options['no-replace']);
-  styleMapToCssFile(_commandLine.options.output);
   cleanHtmlTags(dom);
+  styleMapToCssFile(_commandLine.options.output);
   outputModifiedSrcFile(dom, htmlOutput);
 }; // do the stuff, but on a directory
 
@@ -450,18 +512,20 @@ const filterFiletypes = filenames => {
 const run = async function (runOptions) {
   // use options instead of runOptions if being run through
   // cli as opposed to via another script
-  if (!runOptions) {
-    runOptions = _commandLine.options;
+  if (runOptions) {
+    _commandLine.options = (runOptions, function () {
+      throw new Error('"' + "options" + '" is read-only.');
+    }());
   }
 
-  if (runOptions.help || !runOptions.src && !runOptions.directory) {
+  if (_commandLine.options.help || !_commandLine.options.src && !_commandLine.options.directory) {
     // print help message if not used properly
     console.log(_commandLine.usage);
-  } else if (runOptions.directory) {
-    runDir(runOptions);
+  } else if (_commandLine.options.directory) {
+    runDir(_commandLine.options);
   } else {
     // didn't use directory mode
-    let filenames = runOptions.src;
+    let filenames = _commandLine.options.src;
     filenames = filterFiletypes(filenames);
 
     for (let i = 0; i < filenames.length; i++) {

--- a/src/deprecated-html.js
+++ b/src/deprecated-html.js
@@ -1,0 +1,150 @@
+const deprecatedTags = [
+  'acronym',
+  'applet',
+  'basefont',
+  'big',
+  'center',
+  'dir',
+  'font',
+  'frame',
+  'frameset',
+  'isindex',
+  'noframes',
+  's',
+  'strike',
+  'tt',
+  'u'
+];
+
+const deprecatedAttrs = [
+  'rev',
+  'charset',
+  'shape',
+  'coords',
+  'longdesc',
+  'target',
+  'nohref',
+  'profile',
+  'version',
+  'name',
+  'scheme',
+  'archive',
+  'classid',
+  'codebase',
+  'codetype',
+  'declare',
+  'standby',
+  'valuetype',
+  'type',
+  'axis',
+  'abbr',
+  'scope',
+  'align',
+  'alink',
+  'link',
+  'vlink',
+  'text',
+  'background',
+  'bgcolor',
+  'border',
+  'cellpadding',
+  'cellspacing',
+  'char',
+  'charoff',
+  'clear',
+  'compact',
+  'frame',
+  'compact',
+  'frame',
+  'frameborder',
+  'hspace',
+  'vspace',
+  'marginheight',
+  'marginwidth',
+  'noshade',
+  'nowrap',
+  'rules',
+  'scrolling',
+  'size',
+  'type',
+  'valign',
+  'width'
+];
+
+const isTagDeprecated = (node) => {
+  return deprecatedTags.includes(node.name);
+}
+
+const hasDeprecatedAttrs = (node) => {
+  if (node.attribs) {
+    return Object.keys(node.attribs).some(attr => deprecatedAttrs.includes(attr));
+  }
+
+  // node has no attrs, thus no deprecated attrs
+  return false;
+}
+
+const getDeprecatedAttrsForNode = (node) => {
+  if (node.attribs) {
+    return Object.keys(node.attribs).filter(attr => deprecatedAttrs.includes(attr));
+  }
+
+  // return empty array if node has no attrs
+  return [];
+}
+
+const fontTagSizeToCss = (size) => {
+  const defaultSize = 3;
+
+  // handle relative sizes
+  if (size.charAt(0) === '-') {
+    size = defaultSize - +(size.charAt(1));
+  } else if (size.charAt(1) === '+') {
+    size = defaultSize + +(size.charAt(1));
+  }
+  
+  switch (size) {
+    case 1:
+      size = 'x-small';
+      break;
+
+    case 2:
+      size = 'small';
+      break;
+
+    case 3:
+      size = 'medium';
+      break;
+
+    case 4:
+      size = 'large';
+      break;
+    
+    case 5:
+      size = 'x-large';
+      break;
+
+    case 6:
+      size = 'xx-large';
+      break;
+
+    case 7:
+      size = 'xx-large';
+      break;
+
+    default:
+      size = 'medium';
+      break;
+  }
+
+  return size;
+}
+
+export {
+  deprecatedTags,
+  deprecatedAttrs,
+  isTagDeprecated,
+  hasDeprecatedAttrs,
+  getDeprecatedAttrsForNode,
+  fontTagSizeToCss
+};

--- a/src/index.js
+++ b/src/index.js
@@ -196,15 +196,23 @@ const updateDeprecatedAttr = (node, attr) => {
       break;
 
     case 'cellpadding':
-      attrClass = `padding-${node.attribs[attr]}`;
-      declaration = `border-collapse:collapse;padding:${node.attribs[attr]};`;
+      const match = (node.attribs[attr]).match(/^(\d*|\d*\.\d*)(\w*)$/);
+      let value = match[1] || '';
+      let unit = match[2] || '';
+      unit = unit === '' ? 'px' : unit;
+      attrClass = `padding-${value}${unit}`;
+      declaration = `border-collapse:collapse;padding:${value}${unit};`;
       selectorExtra = ['th', 'td'];
       hasSelectorExtra = true;
       break;
 
     case 'cellspacing':
-      attrClass = `border-spacing-${node.attribs[attr]}`;
-      declaration = `border-collapse:collapse;border-spacing:${node.attribs[attr]};`;
+      const match = (node.attribs[attr]).match(/^(\d*|\d*\.\d*)(\w*)$/);
+      let value = match[1] || '';
+      let unit = match[2] || '';
+      unit = unit === '' ? 'px' : unit;
+      attrClass = `border-spacing-${value}${unit}`;
+      declaration = `border-collapse:collapse;border-spacing:${value}${unit};`;
       selectorExtra = ['th', 'td'];
       hasSelectorExtra = true;
       break;

--- a/src/index.js
+++ b/src/index.js
@@ -187,8 +187,12 @@ const updateDeprecatedAttr = (node, attr) => {
       break;
 
     case 'border':
-      attrClass = `border-width-${node.attribs[attr]}`;
-      declaration = `border-width:${node.attribs[attr]};`;
+      const match = (node.attribs[attr]).match(/^(\d*|\d*\.\d*)(\w*)$/);
+      let value = match[1] || '';
+      let unit = match[2] || '';
+      unit = unit === '' ? 'px' : unit;
+      attrClass = `border-width-${value}${unit}`;
+      declaration = `border-width:${value}${unit};`;
       break;
 
     case 'cellpadding':

--- a/tests/example.jsp
+++ b/tests/example.jsp
@@ -36,23 +36,37 @@ padding:5px;
 <c:import url="Video_51_header.jsp">
 	<c:param name="tagLine" value="Take My Love, Take My Land...You Can't Take The Sky From Me!"></c:param>
 </c:import>
+
+	<font color="black" face="Times New Roman" size="3">
+		<div>
+			<p>This is a test for deprecated font tags</p>
+			<span>Nothing to see here, move along</span>
+		</div>
+	</font>
 	
 	<div id="content" class="testing testing123" style="border: 1px solid black;">
-		<h1>Database: vid_53, image data table</h1>
+		<h1>Database: vid_53, image data table</h1>		
 			
-			
-	<sql:setDataSource var="bunny" dataSource="jdbc/vid_53" />
-	
-	<sql:query var="rabbit" dataSource="${bunny }">SELECT id, imageName, image_extension FROM images</sql:query>
+		<sql:setDataSource var="bunny" dataSource="jdbc/vid_53" />
 		
-	<table style="text-align:left;">
-		<tr><th>id</th><th>name</th><th>extension</th></tr>
-		<c:forEach var="row" items="${rabbit.rows }" >	
-			<tr>
-			<th style="font-weight:bold">record ${row.id }</th><td>${row.imageName }</td><td>${row.image_extension }</td>
-			</tr>	
-		</c:forEach>	
-	</table>	
+		<sql:query var="rabbit" dataSource="${bunny }">SELECT id, imageName, image_extension FROM images</sql:query>
+			
+		<center>
+			<table style="text-align:left;">
+				<tr>
+					<th>id</th>
+					<th>name</th>
+					<th>extension</th>
+				</tr>
+				<c:forEach var="row" items="${rabbit.rows }" >	
+					<tr>
+						<th style="font-weight:bold">record ${row.id }</th>
+						<td>${row.imageName }</td>
+						<td>${row.image_extension }</td>
+					</tr>	
+				</c:forEach>	
+			</table>
+		</center>
 	
 	</div>
 	

--- a/tests/example.jsp
+++ b/tests/example.jsp
@@ -52,14 +52,14 @@ padding:5px;
 		<sql:query var="rabbit" dataSource="${bunny }">SELECT id, imageName, image_extension FROM images</sql:query>
 			
 		<center>
-			<table style="text-align:left;">
+			<table cellpadding="5" bgcolor="white" align="left">
 				<tr>
-					<th>id</th>
+					<th width="10">id</th>
 					<th>name</th>
 					<th>extension</th>
 				</tr>
 				<c:forEach var="row" items="${rabbit.rows }" >	
-					<tr>
+					<tr valign="middle">
 						<th style="font-weight:bold">record ${row.id }</th>
 						<td>${row.imageName }</td>
 						<td>${row.image_extension }</td>

--- a/tests/rec-test/example.jsp
+++ b/tests/rec-test/example.jsp
@@ -44,15 +44,23 @@ padding:5px;
 	<sql:setDataSource var="bunny" dataSource="jdbc/vid_53" />
 	
 	<sql:query var="rabbit" dataSource="${bunny }">SELECT id, imageName, image_extension FROM images</sql:query>
-		
-	<table style="text-align:left;">
-		<tr><th>id</th><th>name</th><th>extension</th></tr>
-		<c:forEach var="row" items="${rabbit.rows }" >	
+	
+	<center>
+		<table style="text-align:left;">
 			<tr>
-			<th style="font-weight:bold">record ${row.id }</th><td>${row.imageName }</td><td>${row.image_extension }</td>
-			</tr>	
-		</c:forEach>	
-	</table>	
+				<th>id</th>
+				<th>name</th>
+				<th>extension</th>
+			</tr>
+			<c:forEach var="row" items="${rabbit.rows }" >	
+				<tr>
+					<th style="font-weight:bold">record ${row.id }</th>
+					<td>${row.imageName }</td>
+					<td>${row.image_extension }</td>
+				</tr>	
+			</c:forEach>	
+		</table>
+	</center>	
 	
 	</div>
 	


### PR DESCRIPTION
Changes:

* Deprecated tags are updated
    * `<center>` -> `<div class="centered">`
    * `<font color="black" face="Times New Roman" size="3">` will have the font properties converted to a class and that class will be added on all direct descendants of the `font` tag. This also applies to `basefont` tags.
* Deprecated attributes are updated
    * `align="left"` -> `.align-left { text-align:left; }`
    * `bgcolor="black"` -> `.(random-className) { background-color:black; }`
    * `border="3" -> `.border-width-3px { border-width:3px; }`
    * `cellpadding="5"` -> `.padding-5px { border-collapse:collapse;padding:5px; }`
    * `cellspacing="7"` -> `.border-spacing-7px { border-collapse:collapse;border-spacing:7px; }`
    * `width="10"` -> `.width-10px { width:10px; }`
    * `valign="middle"` -> `.vert-align-middle { vertical-align:middle; }`