### PR TITLE
Feature/non std tag file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,13 @@
             "program": "${workspaceFolder}/dist/index.js",
             "args": ["tests/example.jsp", "-o", "example_jsp.css", "--no-replace", "modified"],
             "console": "integratedTerminal"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program (Dir mode)",
+            "program": "${workspaceFolder}/dist/index.js",
+            "args": ["-d", "tests", "-r", "-o", "example_dir.css", "-n", "modified"]
         }
     ]
 }

--- a/dist/command-line.js
+++ b/dist/command-line.js
@@ -48,6 +48,10 @@ const optionDefinitions = [{
   alias: 'n',
   type: String
 }, {
+  name: 'interactive',
+  alias: 'i',
+  type: Boolean
+}, {
   name: 'output',
   alias: 'o',
   type: String
@@ -91,6 +95,10 @@ const sections = [{
     alias: 'n',
     typeLabel: '{underline suffix}',
     description: 'The suffix to add onto the end of the html files it would otherwise modify directly ' + 'i.e.: test.html would become test.{underline suffix}.html\n'
+  }, {
+    name: 'interactive',
+    alias: 'i',
+    description: 'If interactive mode is specified, non-standard closing tag input will be gathered on the command line ' + 'line by line, as opposed to the default input file that is generated.'
   }, {
     name: 'output',
     alias: 'o',

--- a/dist/command-line.js
+++ b/dist/command-line.js
@@ -52,6 +52,9 @@ const optionDefinitions = [{
   alias: 'i',
   type: Boolean
 }, {
+  name: 'log',
+  type: Boolean
+}, {
   name: 'output',
   alias: 'o',
   type: String
@@ -99,6 +102,9 @@ const sections = [{
     name: 'interactive',
     alias: 'i',
     description: 'If interactive mode is specified, non-standard closing tag input will be gathered on the command line ' + 'line by line, as opposed to the default input file that is generated.'
+  }, {
+    name: 'log',
+    description: 'If --log is specified a log file will be created that logs all non standard tags ' + 'as well as how the user responded to the prompt. This could be useful for debugging' + 'and keeping track of how certain tags should be handled across multiple runs.'
   }, {
     name: 'output',
     alias: 'o',

--- a/dist/handle-nonstd-tags.js
+++ b/dist/handle-nonstd-tags.js
@@ -15,6 +15,7 @@ const validHtmlTags = ['!--', '!DOCTYPE', 'a', 'abbr', 'acronym', 'address', 'ap
 exports.validHtmlTags = validHtmlTags;
 const foundTags = new Map();
 const promptedTags = [];
+const prompts = [];
 
 const createClosingTag = (tagname, closingTagStr) => {
   return closingTagStr.replace(/\[name\]/, tagname);
@@ -33,7 +34,7 @@ const outputHelpPrompt = () => {
 };
 
 const handleNonStandardTags = async function (tagname, filename, linenumber) {
-  if (!foundTags.has(tagname)) {
+  if (!foundTags.has(tagname) && _commandLine.options.log) {
     // newly encountered non-standard tag
     if (foundTags.size === 0) {
       _fs.default.appendFileSync('nonStdMap.log', '\n===========================================\n'); // first encounter example prompt
@@ -46,11 +47,13 @@ const handleNonStandardTags = async function (tagname, filename, linenumber) {
 
 
     const locationPrompt = `${filename}:${linenumber}`.padEnd(filename.length + 6);
-    const prompt = `${locationPrompt} | tag: <${tagname} : `;
+    const prompt = `${locationPrompt} | tag: <${tagname}`;
     let answer = await (0, _commandLine.waitForInput)(prompt);
     answer = createClosingTag(tagname, answer);
 
-    _fs.default.appendFileSync('nonStdMap.log', `${prompt} ${answer}\n`);
+    if (_commandLine.options.log) {
+      _fs.default.appendFileSync('nonStdMap.log', `${prompt} ${answer}\n`);
+    }
 
     foundTags.set(tagname, createClosingTag(tagname, answer));
   }
@@ -59,18 +62,32 @@ const handleNonStandardTags = async function (tagname, filename, linenumber) {
 exports.handleNonStandardTags = handleNonStandardTags;
 
 const buildNonStandardTagFile = (tagname, filename, linenumber) => {
-  if (!promptedTags.includes(tagname)) {
-    promptedTags.push(tagname);
-    const locationPrompt = `${filename}:${linenumber}`;
-    const prompt = `${locationPrompt} | tag: <${tagname} ...> : \n`;
+  const locationPrompt = `${filename}:${linenumber}`;
+  const prompt = `${locationPrompt} | tag: <${tagname} ...> \n`;
 
-    _fs.default.appendFileSync('non-std-tags.txt', prompt);
+  if (!promptedTags.includes(tagname)) {
+    prompts.push(prompt);
+    promptedTags.push(tagname);
   }
 };
 
 exports.buildNonStandardTagFile = buildNonStandardTagFile;
 
 const waitForTagFileEdit = async function () {
+  // modify the output to keep things in line  
+  const maxLocationLength = Math.max(...prompts.map(prompt => {
+    return prompt.match(/^(.*)\|/)[1].length;
+  }));
+  const maxTagLength = Math.max(...prompts.map(prompt => {
+    return prompt.match(/\| tag:.*/)[0].length;
+  }));
+  prompts.forEach(prompt => {
+    let location = prompt.match(/^.*?:\d+/)[0];
+    let promptEnd = prompt.match(/\| tag:.*/)[0];
+    const formattedPrompt = `${location.padEnd(maxLocationLength)}${promptEnd.padEnd(maxTagLength)} : \n`;
+
+    _fs.default.appendFileSync('non-std-tags.txt', formattedPrompt);
+  });
   console.log('A file named \'non-std-tags.txt\' has been created');
   console.log('in the directory you ran this script from. Please edit');
   console.log('each line according to how the closing tag should');
@@ -83,6 +100,11 @@ const waitForTagFileEdit = async function () {
     if (line.length > 0) {
       const tagname = line.match(/<(.*?)\s*?\.\.\./)[1];
       const closingTag = line.match(/\s:\s*(.*)/)[1] || '';
+
+      if (_commandLine.options.log) {
+        _fs.default.appendFileSync('nonStdMap.log', `${line}${closingTag}\n`);
+      }
+
       foundTags.set(tagname, createClosingTag(tagname, closingTag));
     }
   });

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "main": "dist/inline-exterminator.js",
   "scripts": {
     "test": "npm run build && node dist/index.js tests/example.jsp -o example_jsp.css --no-replace modified",
+    "test-dir": "npm run build && node dist/index.js -d tests -o example_dir.css --no-replace modified",
+    "test-rec": "npm run build && node dist/index.js -r -d tests -o example_rec.css --no-replace modified",
     "build": "babel src --out-dir dist && npm run shebang",
     "shebang": "printf '%s\n%s\n' '#!/usr/bin/env node' \"$(cat dist/index.js)\" > dist/index.js"
   },

--- a/src/command-line.js
+++ b/src/command-line.js
@@ -22,6 +22,7 @@ const optionDefinitions = [
   { name: 'filetype', alias: 't', type: String, multiple: true },
   { name: 'no-replace', alias: 'n', type: String },
   { name: 'interactive', alias: 'i', type: Boolean },
+  { name: 'log', type: Boolean },
   { name: 'output', alias: 'o', type: String },
   { name: 'help', alias: 'h', type: Boolean }
 ];
@@ -77,6 +78,12 @@ const sections = [
         alias: 'i',
         description: 'If interactive mode is specified, non-standard closing tag input will be gathered on the command line ' +
                      'line by line, as opposed to the default input file that is generated.'
+      },
+      {
+        name: 'log',
+        description: 'If --log is specified a log file will be created that logs all non standard tags ' +
+                     'as well as how the user responded to the prompt. This could be useful for debugging' +
+                     'and keeping track of how certain tags should be handled across multiple runs.'
       },
       {
         name: 'output',

--- a/src/command-line.js
+++ b/src/command-line.js
@@ -16,116 +16,123 @@ const packageAlias = 'inlex';
 // <no-replace> : doesn't modify specified files if not null, generates new modified copies instead using the string as the suffix to the filename
 // <output>     : name of the css file to put the stripped inline styles in
 const optionDefinitions = [
-    { name: 'src', type: String, multiple: true, defaultOption: true },
-    { name: 'directory', alias: 'd', type: String },
-    { name: 'recursive', alias: 'r', type: Boolean },
-    { name: 'filetype', alias: 't', type: String, multiple: true },
-    { name: 'no-replace', alias: 'n', type: String },
-    { name: 'output', alias: 'o', type: String },
-    { name: 'help', alias: 'h', type: Boolean }
-  ];
-  
+  { name: 'src', type: String, multiple: true, defaultOption: true },
+  { name: 'directory', alias: 'd', type: String },
+  { name: 'recursive', alias: 'r', type: Boolean },
+  { name: 'filetype', alias: 't', type: String, multiple: true },
+  { name: 'no-replace', alias: 'n', type: String },
+  { name: 'interactive', alias: 'i', type: Boolean },
+  { name: 'output', alias: 'o', type: String },
+  { name: 'help', alias: 'h', type: Boolean }
+];
+
 const options = commandLineArgs(optionDefinitions);
-  
+
 const sections = [
-    {
-        header: packageName,
-        content: `This script will run through HTML and remove inline style attributes and 
+  {
+    header: packageName,
+    content: `This script will run through HTML and remove inline style attributes and 
             tags, and move them to a specified css file. The removed styles will be replaced 
             with random class names in the HTML. Duplicate inline styles will use the same 
             classes. ${packageName}\'s goal is to create more easily maintanable code.`
-    },
-    {
-        header: 'Options',
-        optionList: [
-            {
-                name: 'src',
-                typeLabel: '{underline file}',
-                multiple: true,
-                defaultOption: true,
-                description: 'The file(s) to run this script on. multiple files can be specified by repeating the --src flag.\n'
-            },
-            {
-                name: 'directory',
-                typeLabel: '{underline dir}',
-                alias: 'd',
-                description: '(Not yet implemented) The directory to run this script on. Doesn\'t work without the --filetype ' +
-                'option to avoid operating on every file.\n'
-            },
-            {
-                name: 'recursive',
-                alias: 'r',
-                description: `(Not yet implemented) If this option is used ${packageName} will work recursively through all directories starting with the directory the script is run in as the root directory.\n`
-            },
-            {
-                name: 'filetype',
-                alias: 't',
-                typeLabel: '{underline filetype}',
-                description: '(Not yet implemented) The file type to limit operations to. This will prevent IA from ' +
-                'modifying every file while it attempts to remove inline styles.\n'
-            },
-            {
-                name: 'no-replace',
-                alias: 'n',
-                typeLabel: '{underline suffix}',
-                description: 'The suffix to add onto the end of the html files it would otherwise modify directly ' +
-                'i.e.: test.html would become test.{underline suffix}.html\n'
-            },
-            {
-                name: 'output',
-                alias: 'o',
-                typeLabel: '{underline filename.css}',
-                description: 'The name of the file to save the extracted inline styles in. This will be formatted as vanilla CSS.\n'
-            },
-            {
-                name: 'help',
-                alias: 'h',
-                description: 'Print this help message.\n'
-            }
-        ]
-    },
-    {
-        header: 'Examples',
-        content: {
-            options: { maxWidth: 150 },
-            data: [
-                {
-                    desc: `1. Basic usage. --src can be ommitted if ${packageName} used on only one file\n`,
-                    example: `${packageName} example.html --output example.css`
-                },
-                {
-                    desc: `2. No-replace flag. The file being operated on (example.html) will not be modified. example.clean.html will be created.\n`,
-                    example: `${packageName} example.html --output example.css --no-replace clean`
-                },
-                {
-                    desc: `3. Directory flag. ${packageName} will run on the specified directory (relative to the directory you're running it from)\n`,
-                    example: `${packageAlias} -d my-dirty-html -o example.css`
-                },
-                {
-                    desc: `4. Filetype flag. Used in conjunction with the directory flag, it will run on all files in the directory with the specified file extension.`,
-                    example: `${packageAlias} -d my-dirty-html -t *.html -o example.css`
-                },
-                {
-                    desc: `5. Recursive flag. Used in conjunction with directory mode, using this flag tells ${packageName} to run in the specified directory and all subdirectories.`,
-                    example: `${packageAlias} -rd my-dirt-html -o example.css`
-                }
-            ]
+  },
+  {
+    header: 'Options',
+    optionList: [
+      {
+        name: 'src',
+        typeLabel: '{underline file}',
+        multiple: true,
+        defaultOption: true,
+        description: 'The file(s) to run this script on. multiple files can be specified by repeating the --src flag.\n'
+      },
+      {
+        name: 'directory',
+        typeLabel: '{underline dir}',
+        alias: 'd',
+        description: '(Not yet implemented) The directory to run this script on. Doesn\'t work without the --filetype ' +
+          'option to avoid operating on every file.\n'
+      },
+      {
+        name: 'recursive',
+        alias: 'r',
+        description: `(Not yet implemented) If this option is used ${packageName} will work recursively through all directories starting with the directory the script is run in as the root directory.\n`
+      },
+      {
+        name: 'filetype',
+        alias: 't',
+        typeLabel: '{underline filetype}',
+        description: '(Not yet implemented) The file type to limit operations to. This will prevent IA from ' +
+          'modifying every file while it attempts to remove inline styles.\n'
+      },
+      {
+        name: 'no-replace',
+        alias: 'n',
+        typeLabel: '{underline suffix}',
+        description: 'The suffix to add onto the end of the html files it would otherwise modify directly ' +
+          'i.e.: test.html would become test.{underline suffix}.html\n'
+      },
+      {
+        name: 'interactive',
+        alias: 'i',
+        description: 'If interactive mode is specified, non-standard closing tag input will be gathered on the command line ' +
+                     'line by line, as opposed to the default input file that is generated.'
+      },
+      {
+        name: 'output',
+        alias: 'o',
+        typeLabel: '{underline filename.css}',
+        description: 'The name of the file to save the extracted inline styles in. This will be formatted as vanilla CSS.\n'
+      },
+      {
+        name: 'help',
+        alias: 'h',
+        description: 'Print this help message.\n'
+      }
+    ]
+  },
+  {
+    header: 'Examples',
+    content: {
+      options: { maxWidth: 150 },
+      data: [
+        {
+          desc: `1. Basic usage. --src can be ommitted if ${packageName} used on only one file\n`,
+          example: `${packageName} example.html --output example.css`
+        },
+        {
+          desc: `2. No-replace flag. The file being operated on (example.html) will not be modified. example.clean.html will be created.\n`,
+          example: `${packageName} example.html --output example.css --no-replace clean`
+        },
+        {
+          desc: `3. Directory flag. ${packageName} will run on the specified directory (relative to the directory you're running it from)\n`,
+          example: `${packageAlias} -d my-dirty-html -o example.css`
+        },
+        {
+          desc: `4. Filetype flag. Used in conjunction with the directory flag, it will run on all files in the directory with the specified file extension.`,
+          example: `${packageAlias} -d my-dirty-html -t *.html -o example.css`
+        },
+        {
+          desc: `5. Recursive flag. Used in conjunction with directory mode, using this flag tells ${packageName} to run in the specified directory and all subdirectories.`,
+          example: `${packageAlias} -rd my-dirt-html -o example.css`
         }
+      ]
     }
+  }
 ];
 
 const usage = commandLineUsage(sections);
 
 const waitForInput = (prompt) => {
-    const rl = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout
-    });
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });
 
-    return new Promise(resolve => rl.question(prompt, ans => {
-        rl.close();
-        resolve(ans);
-    }));
+  return new Promise(resolve => rl.question(prompt, ans => {
+    rl.close();
+    resolve(ans);
+  }));
 }
 
 export { options, usage, waitForInput };


### PR DESCRIPTION
Changes:

* Non-standard tags are now output into a file that the user interacts with to provide input for all non-standard tags at once.
* Old command line interaction is still accessible via the `-i` or `--interactive` flag
* nonStdMap.log is no longer generated by default. It can be turned on using the `--log` flag.